### PR TITLE
fixed restart function init.d scripts. would not timeout properly.

### DIFF
--- a/sensu_configs/init.d/sensu-api
+++ b/sensu_configs/init.d/sensu-api
@@ -223,6 +223,7 @@ restart() {
     stop
 
     while [ $count -lt $max_wait ]; do
+        count=$((count + 1))        
         status &> /dev/null
         if [ $? -eq 0 ]; then
             # still running

--- a/sensu_configs/init.d/sensu-client
+++ b/sensu_configs/init.d/sensu-client
@@ -223,6 +223,7 @@ restart() {
     stop
 
     while [ $count -lt $max_wait ]; do
+        count=$((count + 1))        
         status &> /dev/null
         if [ $? -eq 0 ]; then
             # still running

--- a/sensu_configs/init.d/sensu-dashboard
+++ b/sensu_configs/init.d/sensu-dashboard
@@ -223,6 +223,7 @@ restart() {
     stop
 
     while [ $count -lt $max_wait ]; do
+        count=$((count + 1))
         status &> /dev/null
         if [ $? -eq 0 ]; then
             # still running

--- a/sensu_configs/init.d/sensu-server
+++ b/sensu_configs/init.d/sensu-server
@@ -223,6 +223,7 @@ restart() {
     stop
 
     while [ $count -lt $max_wait ]; do
+        count=$((count + 1))
         status &> /dev/null
         if [ $? -eq 0 ]; then
             # still running


### PR DESCRIPTION
timeouts were not fully implemented in the `restart` functions of the init scripts.  Found during testing of ubuntu 12.04.
