### PR TITLE
fixed bug in rpm pre-uninstall script that would cause removal to fail. 

### DIFF
--- a/pkg_scripts/rpm/preun
+++ b/pkg_scripts/rpm/preun
@@ -5,11 +5,11 @@ if [ $1 -eq 0 ]; then
   /etc/init.d/sensu-client stop
   /etc/init.d/sensu-dashboard stop
 
-  if ! getent passwd sensu >/dev/null; then
+  if getent passwd sensu >/dev/null; then
       /usr/sbin/userdel sensu
   fi  
   
-  if ! getent group sensu >/dev/null; then
+  if getent group sensu >/dev/null; then
       /usr/sbin/groupdel sensu
   fi
 


### PR DESCRIPTION
The `userdel sensu` command was also removing the group so when the subsequent
`groupdel sensu` was called it would fail with error "no such group". This failure would
prevent rpm from fully removing the package from the system.
