### PR TITLE
Set PATH after platform specific bits

### DIFF
--- a/sensu_configs/init.d/sensu-api
+++ b/sensu_configs/init.d/sensu-api
@@ -40,7 +40,6 @@ pidfile=${PIDFILE-/var/run/sensu/$prog.pid}
 options=${OPTIONS}
 
 cd $sensu_home
-export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ## 
 ## Set platform specific bits here.
@@ -112,6 +111,8 @@ if [ "$system" = "debian" ]; then
     }
 fi
 # TODO: support other platforms in the future: suse, gentoo, arch, slackware, etc
+
+export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ensure_pid_dir () {
     pid_dir=`dirname ${pidfile}`

--- a/sensu_configs/init.d/sensu-client
+++ b/sensu_configs/init.d/sensu-client
@@ -40,7 +40,6 @@ pidfile=${PIDFILE-/var/run/sensu/$prog.pid}
 options=${OPTIONS}
 
 cd $sensu_home
-export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ## 
 ## Set platform specific bits here.
@@ -112,6 +111,7 @@ if [ "$system" = "debian" ]; then
     }
 fi
 # TODO: support other platforms in the future: suse, gentoo, arch, slackware, etc
+export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ensure_pid_dir () {
     pid_dir=`dirname ${pidfile}`

--- a/sensu_configs/init.d/sensu-dashboard
+++ b/sensu_configs/init.d/sensu-dashboard
@@ -40,7 +40,6 @@ pidfile=${PIDFILE-/var/run/sensu/$prog.pid}
 options=${OPTIONS}
 
 cd $sensu_home
-export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ## 
 ## Set platform specific bits here.
@@ -112,6 +111,7 @@ if [ "$system" = "debian" ]; then
     }
 fi
 # TODO: support other platforms in the future: suse, gentoo, arch, slackware, etc
+export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ensure_pid_dir () {
     pid_dir=`dirname ${pidfile}`

--- a/sensu_configs/init.d/sensu-server
+++ b/sensu_configs/init.d/sensu-server
@@ -40,7 +40,6 @@ pidfile=${PIDFILE-/var/run/sensu/$prog.pid}
 options=${OPTIONS}
 
 cd $sensu_home
-export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ## 
 ## Set platform specific bits here.
@@ -112,6 +111,7 @@ if [ "$system" = "debian" ]; then
     }
 fi
 # TODO: support other platforms in the future: suse, gentoo, arch, slackware, etc
+export PATH=$PATH:/etc/sensu/plugins:/usr/local/sbin:/usr/local/bin
 
 ensure_pid_dir () {
     pid_dir=`dirname ${pidfile}`


### PR DESCRIPTION
/etc/init.d/functions clobbers $PATH in Centos causing handlers/plugins
to fail with 'env: ruby: No such file or directory'  if ruby is not in
/sbin:/usr/sbin/:/bin:/usr/bin
