### PR TITLE
Look for init children only in init.d status/stop

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -217,7 +217,7 @@ stop() {
         fi
         return $retval
     else
-        pid=$(pgrep -fl $exec | grep -v grep | grep -v bash | cut -f1 -d" ")
+        pid=$(pgrep -P1 -fl $exec | grep -v grep | grep -v bash | cut -f1 -d" ")
         if [ ! "$pid" == "" ]; then
             kill $pid
             retval=$?


### PR DESCRIPTION
I have an LXC environment with multiple containers running on a single server. Each container has its separate sensu client, and the host server has one as well.

Currently 'sensu-client status' executed on a host system will report multiple PIDs of sensu clients running in all LXC containers, and will report success even if sensu-client is not running on the host system itself.

This change makes pgrep only look for processess that are direct children on init, ignoring anything running in containers as the result.
