### PR TITLE
Add right path to make cron happy

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -124,7 +124,7 @@ if [ "$system" = "debian" ]; then
 
     ## set or override platform specific functions
     start_daemon() {
-        start-stop-daemon --start --chuid $1 --pidfile $2 --exec $3 -- $4
+        /sbin/start-stop-daemon --start --chuid $1 --pidfile $2 --exec $3 -- $4
     }
     echo_ok() {
         log_end_msg 0


### PR DESCRIPTION
Default PATH for cron environment on Debian/Ubuntu does not contain /sbin as a valid path, so, when invoking "sensu-client start" or "sensu-client restart" within a cronjob, it will fail.
Using the full path (/sbin/start-stop-daemon) fixes the problem
