### PR TITLE
Fix logrotate's postrotate script - it shouldn't fail when the process in the PID file isn't running

### DIFF
--- a/sensu_configs/logrotate.d/sensu
+++ b/sensu_configs/logrotate.d/sensu
@@ -7,7 +7,7 @@
     copytruncate
     compress
     postrotate
-        /bin/kill -USR2 `cat /var/run/sensu/sensu-client.pid 2> /dev/null` 2> /dev/null || true
+        kill -USR2 `cat /var/run/sensu/sensu-client.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }
 
@@ -20,7 +20,7 @@
     copytruncate
     compress
     postrotate
-        /bin/kill -USR2 `cat /var/run/sensu/sensu-server.pid 2> /dev/null` 2> /dev/null || true
+        kill -USR2 `cat /var/run/sensu/sensu-server.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }
 
@@ -33,7 +33,7 @@
     copytruncate
     compress
     postrotate
-        /bin/kill -USR2 `cat /var/run/sensu/sensu-api.pid 2> /dev/null` 2> /dev/null || true
+        kill -USR2 `cat /var/run/sensu/sensu-api.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }
 
@@ -46,6 +46,6 @@
     copytruncate
     compress
     postrotate
-        /bin/kill -USR2 `cat /var/run/sensu/sensu-dashboard.pid 2> /dev/null` 2> /dev/null || true
+        kill -USR2 `cat /var/run/sensu/sensu-dashboard.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
We should fail gracefully if the process referenced in the pid file isn't actually running. This solves the nightly cron error we were getting:

/etc/cron.daily/logrotate:
logrotate_script: 2: kill: No such process

error: error running shared postrotate script for '/var/log/sensu/sensu-client.log '
run-parts: /etc/cron.daily/logrotate exited with return code 1
