### PR TITLE
enable setting max_wait from /etc/default/sensu

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -21,6 +21,7 @@ HANDLERS_DIR=/etc/sensu/handlers
 LOG_DIR=/var/log/sensu
 PID_DIR=/var/run/sensu
 USER=sensu
+SERVICE_MAX_WAIT=10
 
 if [ -f /etc/default/sensu ]; then
     . /etc/default/sensu
@@ -271,16 +272,11 @@ status() {
 # sometimes sensu components need a moment to shutdown, so
 # let's implement a waiting approach to restarts with a timeout
 restart() {
-
-    if [ -z "$max_wait" ]; then
-        max_wait=10
-    fi
-
     count=0; success=0
 
     stop
 
-    while [ $count -lt $max_wait ]; do
+    while [ $count -lt $SERVICE_MAX_WAIT ]; do
         count=$((count + 1))
         status &> /dev/null
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
wrapped max_wait variable in if string is null statement set it to default value, else carry on.
Allows you to set max_wait in /etc/default/sensu to user defined value for plugins that run for longer than the default 10 secs.
