### PR TITLE
Rotate client logs on size

### DIFF
--- a/sensu_configs/logrotate.d/sensu
+++ b/sensu_configs/logrotate.d/sensu
@@ -1,6 +1,7 @@
 /var/log/sensu/sensu-client.log {
     rotate 7
     daily
+    size 200M
     missingok
     notifempty
     sharedscripts


### PR DESCRIPTION
Many of my sensu-clients are checking more than 100 checks which results in a sensu-client.log in 4GB in size daily! This is an issue because our root volume is kept pretty small. This change ensures the file size doesn't go above 200MBs in size.
