### PR TITLE
Add dependencies for init.d scripts

### DIFF
--- a/sensu_configs/init.d/sensu-api
+++ b/sensu_configs/init.d/sensu-api
@@ -5,8 +5,8 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-api
-# Required-Start: $remote_fs $network
-# Required-Stop:  $remote_fs $network
+# Required-Start: $remote_fs $network redis-server
+# Required-Stop:  $remote_fs $network redis-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework api

--- a/sensu_configs/init.d/sensu-api
+++ b/sensu_configs/init.d/sensu-api
@@ -5,8 +5,10 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-api
-# Required-Start: $remote_fs $network redis-server
-# Required-Stop:  $remote_fs $network redis-server
+# Required-Start: $remote_fs $network
+# Required-Stop:  $remote_fs $network
+# Should-Start: redis-server
+# Should-Stop: redis-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework api

--- a/sensu_configs/init.d/sensu-client
+++ b/sensu_configs/init.d/sensu-client
@@ -5,8 +5,10 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-client
-# Required-Start: $remote_fs $network rabbitmq-server
-# Required-Stop:  $remote_fs $network rabbitmq-server
+# Required-Start: $remote_fs $network
+# Required-Stop:  $remote_fs $network
+# Should-Start: rabbitmq-server
+# Should-Stop: rabbitmq-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework client

--- a/sensu_configs/init.d/sensu-client
+++ b/sensu_configs/init.d/sensu-client
@@ -5,8 +5,8 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-client
-# Required-Start: $remote_fs $network
-# Required-Stop:  $remote_fs $network
+# Required-Start: $remote_fs $network rabbitmq-server
+# Required-Stop:  $remote_fs $network rabbitmq-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework client

--- a/sensu_configs/init.d/sensu-server
+++ b/sensu_configs/init.d/sensu-server
@@ -5,8 +5,10 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-server
-# Required-Start: $remote_fs $network rabbitmq-server
-# Required-Stop:  $remote_fs $network rabbitmq-server
+# Required-Start: $remote_fs $network
+# Required-Stop:  $remote_fs $network
+# Should-Start: rabbitmq-server
+# Should-Stop: rabbitmq-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework server

--- a/sensu_configs/init.d/sensu-server
+++ b/sensu_configs/init.d/sensu-server
@@ -5,8 +5,8 @@
 
 ### BEGIN INIT INFO
 # Provides:       sensu-server
-# Required-Start: $remote_fs $network
-# Required-Stop:  $remote_fs $network
+# Required-Start: $remote_fs $network rabbitmq-server
+# Required-Stop:  $remote_fs $network rabbitmq-server
 # Default-Start:  2 3 4 5
 # Default-Stop:   0 1 6
 # Description:    Sensu monitoring framework server


### PR DESCRIPTION
The init.d scripts lacks dependencies on redis-sever and rabbitmq-server
(not all of them need them both). This dependancies lacking may prevent
some Sensu service to start when the machine is rebooted.