### PR TITLE
Follow man of a delgroup cmd

### DIFF
--- a/pkg_scripts/rpm/postun
+++ b/pkg_scripts/rpm/postun
@@ -31,6 +31,6 @@ if [ $1 -eq 0 ]; then
 
     # Delete sensu group
     if getent group sensu >/dev/null; then
-        groupdel -f sensu
+        groupdel sensu
     fi
 fi


### PR DESCRIPTION
As groupdel do not have anything like -f flag.

But without fix this postun gives on suse 11sp3:

```
error: %postun(sensu-0.12.2-1.x86_64) scriptlet failed, exit status 2
```
