### PR TITLE
Support for OpenSuSE 13.1 32bit / 64bit added

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,9 @@ build_boxes = {
   :centos_5_10_32  => "#{opscode_bento}/opscode_centos-5.10-i386_chef-provisionerless.box",
   :centos_5_10_64  => "#{opscode_bento}/opscode_centos-5.10_chef-provisionerless.box",
   :ubuntu_10_04_32 => "#{opscode_bento}/opscode_ubuntu-10.04-i386_chef-provisionerless.box",
-  :ubuntu_10_04_64 => "#{opscode_bento}/opscode_ubuntu-10.04_chef-provisionerless.box"
+  :ubuntu_10_04_64 => "#{opscode_bento}/opscode_ubuntu-10.04_chef-provisionerless.box",
+  :opensuse_13_01_64 => "#{opscode_bento}/opscode_opensuse-13.1-x86_64_chef-provisionerless.box",
+  :opensuse_13_01_32 => "#{opscode_bento}/opscode_opensuse-13.1-i386_chef-provisionerless.box"
 }
 
 Vagrant.configure("2") do |config|
@@ -28,7 +30,7 @@ Vagrant.configure("2") do |config|
     :inline => "export VAGRANT_BOX=true ; \
                 export SENSU_VERSION=#{ENV['SENSU_VERSION']} ; \
                 export BUILD_NUMBER=#{ENV['BUILD_NUMBER']} ; \
-                cd /vagrant && ./build.sh && shutdown -h now"
+                cd /vagrant && ./build.sh && /sbin/shutdown -h now"
   build_boxes.each do |name, url|
     config.vm.define name do |build_box|
       build_box.vm.box = name.to_s

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -41,7 +41,7 @@ case "$system" in
         ;;
 
     suse)
-        zypper --non-interactive install curl m4 make gcc gcc-c++
+        zypper --non-interactive install curl m4 make gcc gcc-c++ rpm-build
         ;;
 
     *)

--- a/para-vagrant.sh
+++ b/para-vagrant.sh
@@ -56,4 +56,6 @@ centos_5_10_32
 centos_5_10_64
 ubuntu_10_04_32
 ubuntu_10_04_64
+opensuse_13_01_64
+opensuse_13_01_32
 EOF


### PR DESCRIPTION
Needed packages for OpenSuSE & SuSE Linux Enterprise Server & added the respective opscode bento images & some minor adjustments to the build process.

Note that currently the URL for pyyaml needs to be adjusted to the following due to pyyaml.org downtime:
`http://pkgs.fedoraproject.org/repo/pkgs/libyaml/yaml-0.1.4.tar.gz/36c852831d02cf90508c29852361d01b/yaml-0.1.4.tar.gz`
