### PR TITLE
Update sensu-services init.d

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -102,6 +102,7 @@ fi
 if [ "$system" = "debian" ]; then
     ## source platform specific external scripts
     . /lib/lsb/init-functions
+    prog=sensu-$1
     [ -r /etc/default/$prog ] && . /etc/default/$prog
 
     ## set or override platform specific variables


### PR DESCRIPTION
Debian overwrite the variable $prog, this is a workaround. A more definitive solution would be to rename the variable
