### PR TITLE
change order for rc script

### DIFF
--- a/sensu_configs/init.d/sensu-api
+++ b/sensu_configs/init.d/sensu-api
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework api
 
 ### BEGIN INIT INFO

--- a/sensu_configs/init.d/sensu-client
+++ b/sensu_configs/init.d/sensu-client
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework client
 
 ### BEGIN INIT INFO

--- a/sensu_configs/init.d/sensu-server
+++ b/sensu_configs/init.d/sensu-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework server
 
 ### BEGIN INIT INFO

--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework service
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
sensu processes should terminate earlier than other processes.
The case of setting for automatic start in process monitoring,
it will start the process that has become stopped by shutdown process.