### PR TITLE
Push the rpms up to rhel 7 yum repo

### DIFF
--- a/scripts/upload
+++ b/scripts/upload
@@ -11,6 +11,7 @@ rpms=`find . -name "*.rpm"`
 for r in $rpms; do
     package_cloud push sensu/stable/el/5 $r
     package_cloud push sensu/stable/el/6 $r
+    package_cloud push sensu/stable/el/7 $r
 done
 
 echo 'done.'


### PR DESCRIPTION
Pushes the RPMS up to the RHEL 7 repos.

I checked out the RPMS on built via the normal processes and they seem to work, barring some centos 7 specific binary targets or systemd scripts, the current omnibus tooling should be fine.
