### PR TITLE
allow parameters override from executor script

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -15,14 +15,14 @@
 service=sensu-$1
 
 EMBEDDED_RUBY=false
-CONFIG_FILE=/etc/sensu/config.json
-CONFIG_DIR=/etc/sensu/conf.d
-EXTENSION_DIR=/etc/sensu/extensions
-PLUGINS_DIR=/etc/sensu/plugins
-HANDLERS_DIR=/etc/sensu/handlers
-LOG_DIR=/var/log/sensu
-LOG_LEVEL=info
-PID_DIR=/var/run/sensu
+CONFIG_FILE=${CONFIG_FILE:-/etc/sensu/config.json}
+CONFIG_DIR=${CONFIG_DIR:-/etc/sensu/conf.d}
+EXTENSION_DIR=${EXTENSION_DIR:-/etc/sensu/extensions}
+PLUGINS_DIR=${PLUGINS_DIR:-/etc/sensu/plugins}
+HANDLERS_DIR=${HANDLERS_DIR:-/etc/sensu/handlers}
+LOG_DIR=${LOG_DIR:-/var/log/sensu}
+LOG_LEVEL=${LOG_LEVEL:-info}
+PID_DIR=${PID_DIR:-/var/run/sensu}
 USER=sensu
 SERVICE_MAX_WAIT=10
 


### PR DESCRIPTION
the proposed fix will allow to override the parameters in the sensu-client script for example 

$app="client"
export CONFIG_FILE=/etc/sensu/$app/config.json
export CONFIG_DIR=/etc/sensu/$app/conf.d
export EXTENSION_DIR=/etc/sensu/$app/extensions
export PLUGINS_DIR=/etc/sensu/$app/plugins
export HANDLERS_DIR=/etc/sensu/$app/handlers
export PID_DIR=/var/run/sensu/$app
