### PR TITLE
prevent wrong status of the process

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -248,7 +248,7 @@ status() {
     local pid
 
     # First try "ps"
-    pid=$(pgrep -P1 -fl $exec | grep -v grep | grep -v bash | cut -f1 -d" ")
+    pid=$(pgrep -P1 -fl " $exec " | grep -v grep | grep -v bash | cut -f1 -d" ")
     if [ -n "$pid" ]; then
         log_action_msg "$service (pid $pid) is running"
         return 0


### PR DESCRIPTION
currently if exec = /opt/sensu/bin/sensu-client
and running process is /opt/sensu/bin/sensu-client-xxxxx the process will not start because it thinks that the process is running.