### PR TITLE
Remove 'copytruncate' from logrotate config

### DIFF
--- a/sensu_configs/logrotate.d/sensu
+++ b/sensu_configs/logrotate.d/sensu
@@ -4,7 +4,6 @@
     missingok
     notifempty
     sharedscripts
-    copytruncate
     compress
     postrotate
         kill -USR2 `cat /var/run/sensu/sensu-client.pid 2> /dev/null` 2> /dev/null || true
@@ -17,7 +16,6 @@
     missingok
     notifempty
     sharedscripts
-    copytruncate
     compress
     postrotate
         kill -USR2 `cat /var/run/sensu/sensu-server.pid 2> /dev/null` 2> /dev/null || true
@@ -30,7 +28,6 @@
     missingok
     notifempty
     sharedscripts
-    copytruncate
     compress
     postrotate
         kill -USR2 `cat /var/run/sensu/sensu-api.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
In logrotate, the general rule is that you should not use copytruncate unless the daemon writing to the log doesn't support logfile handle reloading.  Sensu does this well via the USR2 signal, and that signal is used properly via the postrotate command already here.

There are three main drawbacks to using copytruncate.  The first is that there is a rather high probability that some log lines will be lost in the rotation process.  The second is a matter of speed.  With debug logging enabled, logrotate was taking 50 seconds when using copytruncate.   When I applied this patch, the same run took less than a second.  The third problem is that the copytruncate requires there to be at least as much free space available on the disk as the size of the uncompressed log.

In summary, when using a daemon like Sensu that does proper logfile handle reloading, it's best to not use copytruncate :)