### PR TITLE
log level from /etc/default

### DIFF
--- a/sensu_configs/upstart/sensu-api.conf
+++ b/sensu_configs/upstart/sensu-api.conf
@@ -23,6 +23,7 @@ script
   PLUGINS_DIR=/etc/sensu/plugins
   HANDLERS_DIR=/etc/sensu/handlers
   LOG_DIR=/var/log/sensu
+  LOG_LEVEL=info
   USER=sensu
 
   if [ -f /etc/default/sensu ]; then
@@ -31,7 +32,7 @@ script
 
   logfile=$LOG_DIR/$PROG.log
 
-  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile $OPTIONS"
+  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile --log_level $LOG_LEVEL $OPTIONS"
 
   if [ "x$EMBEDDED_RUBY" = "xtrue" ]; then
     export PATH=/opt/sensu/embedded/bin:$PATH:$PLUGINS_DIR:$HANDLERS_DIR

--- a/sensu_configs/upstart/sensu-client.conf
+++ b/sensu_configs/upstart/sensu-client.conf
@@ -23,6 +23,7 @@ script
   PLUGINS_DIR=/etc/sensu/plugins
   HANDLERS_DIR=/etc/sensu/handlers
   LOG_DIR=/var/log/sensu
+  LOG_LEVEL=info
   USER=sensu
 
   if [ -f /etc/default/sensu ]; then
@@ -31,7 +32,7 @@ script
 
   logfile=$LOG_DIR/$PROG.log
 
-  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile $OPTIONS"
+  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile --log_level $LOG_LEVEL $OPTIONS"
 
   if [ "x$EMBEDDED_RUBY" = "xtrue" ]; then
     export PATH=/opt/sensu/embedded/bin:$PATH:$PLUGINS_DIR:$HANDLERS_DIR

--- a/sensu_configs/upstart/sensu-server.conf
+++ b/sensu_configs/upstart/sensu-server.conf
@@ -23,6 +23,7 @@ script
   PLUGINS_DIR=/etc/sensu/plugins
   HANDLERS_DIR=/etc/sensu/handlers
   LOG_DIR=/var/log/sensu
+  LOG_LEVEL=info
   USER=sensu
 
   if [ -f /etc/default/sensu ]; then
@@ -31,7 +32,7 @@ script
 
   logfile=$LOG_DIR/$PROG.log
 
-  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile $OPTIONS"
+  options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -l $logfile --log_level $LOG_LEVEL $OPTIONS"
 
   if [ "x$EMBEDDED_RUBY" = "xtrue" ]; then
     export PATH=/opt/sensu/embedded/bin:$PATH:$PLUGINS_DIR:$HANDLERS_DIR


### PR DESCRIPTION
Brings upstart script inline with Sensu doc which recommends setting log level in /etc/default/sensu