### PR TITLE
Fixing sensu-service init script for containers

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -172,7 +172,7 @@ set_sensu_paths() {
 }
 
 pid_pgrep() {
-    pgrep -f -u $USER " $exec "
+    pgrep -f -P 1 -u $USER " $exec "
 }
 
 wait_for_stop() {


### PR DESCRIPTION
Check the parent ppid to ensure only the sensu service on the host machine will be affected otherwise on a host that serves containers, it'll grab container pids as well as the host pid.  IE restarting the sensu service on the host machine will restart all of the sensu services on the containers it serves as well.

See this issue:

https://github.com/sensu/sensu/issues/974