### PR TITLE
Add Centos7 / Systemd detection to sensu-ctl

### DIFF
--- a/runit_scripts/sensu-ctl.rb
+++ b/runit_scripts/sensu-ctl.rb
@@ -139,6 +139,8 @@ def configure
   when "redhat", "centos", "rhel", "scientific"
     if ohai.platform_version =~ /^6/
       setup_runsvdir_upstart
+    elsif ohai.platform_version =~ /^7/
+      setup_runsvdir_systemd
     else
       setup_runsvdir_sysvinit
     end


### PR DESCRIPTION
CentOS7 / RHEL 7 is based on systemd. Absent this change sensu-ctl tries to add sensu to /etc/inittab which has no effect.