### PR TITLE
groupdel(8) has no such parameter '-f'

### DIFF
--- a/pkg_scripts/deb/postrm
+++ b/pkg_scripts/deb/postrm
@@ -41,7 +41,7 @@ purge_sensu_user_group() {
         userdel -f sensu
     fi
     if getent group sensu >/dev/null; then
-        groupdel -f sensu
+        groupdel sensu
     fi
 }
 


### PR DESCRIPTION
Removed paramter '-f' from `postrm` script otherwise `apt-get purge
sensu` fails to complete successfully.

```
mbp0 /home/rw > sudo apt-get purge sensu
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED
  sensu*
0 to upgrade, 0 to newly install, 1 to remove and 140 not to upgrade.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n]
(Reading database ... 268527 files and directories currently installed.)
Removing sensu (0.20.1-1) ...
Purging configuration files for sensu (0.20.1-1) ...
groupdel: invalid option -- 'f'
Usage: groupdel [options] GROUP

Options:
  -h, --help                    display this help message and exit
  -R, --root CHROOT_DIR         directory to chroot into

dpkg: error processing package sensu (--purge):
 subprocess installed post-removal script returned error exit status 2
Errors were encountered while processing:
 sensu
E: Sub-process /usr/bin/dpkg returned an error code (1)
mbp0 /home/rw 100> lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 15.04
Release:        15.04
Codename:       vivid
mbp0 /home/rw >
```

I think this problem was accidently introduced in
https://github.com/sensu/sensu-build/commit/694924bb6db2c26f999b3ce1996d49206af396e0#diff-40afb2512e360336d91122a47544a717 when switching from `deluser --force` to `userdel -f` and `groupdel`.