### PR TITLE
move /etc/default/sensu sourcing to a different line to keep PATH persistence. 

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -26,9 +26,6 @@ PID_DIR=/var/run/sensu
 USER=sensu
 SERVICE_MAX_WAIT=10
 
-if [ -f /etc/default/sensu ]; then
-    . /etc/default/sensu
-fi
 
 system=unknown
 if [ -f /etc/redhat-release ]; then
@@ -145,6 +142,9 @@ if [ "$system" = "suse" ]; then
     }
 fi
 
+if [ -f /etc/default/sensu ]; then
+    . /etc/default/sensu
+fi
 cd /opt/sensu
 
 exec=/opt/sensu/bin/$sensu_service


### PR DESCRIPTION
sourcing the /etc/default/sensu file may need to happen at a later stage as the any path variable ($PATH) set in the /etc/default/sensu file gets overwritten in subsequent functions. If I set plugin paths or handler paths in the /etc/default/sensu the server doesn't pick that up as PATH variable gets reset when the 
. /etc/init.d/functions file is called (in redhat). 
