### PR TITLE
Set EMBEDDED_RUBY=true by default, using embedded Ruby for plugins

### DIFF
--- a/sensu_configs/default/sensu
+++ b/sensu_configs/default/sensu
@@ -1,1 +1,1 @@
-EMBEDDED_RUBY=false
+EMBEDDED_RUBY=true


### PR DESCRIPTION
Setting EMBEDDED_RUBY to `true` by default would include the Sensu embedded bin path in the Sensu `$PATH` which is used when executing checks & handlers.