### PR TITLE
Also default EMBEDDED_RUBY=true in init script

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -14,7 +14,7 @@
 
 sensu_service=sensu-$1
 
-EMBEDDED_RUBY=false
+EMBEDDED_RUBY=true
 CONFIG_FILE=/etc/sensu/config.json
 CONFIG_DIR=/etc/sensu/conf.d
 EXTENSION_DIR=/etc/sensu/extensions


### PR DESCRIPTION
- already defaulting to true in /etc/default/sensu