### PR TITLE
[init] add optional client deregisration on stop

### DIFF
--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -199,7 +199,7 @@ wait_for_stop() {
 
 deregister_client() {
     log_action_msg "Deregistering sensu-client"
-    echo "{ \"name\": \"api_call\", \"output\": \"delete\", \"process\": \"init\", \"user\": \"root\", \"status\": 2, \"handler\": \"${CLIENT_DEREGISTER_HANDLER}\"}" > \
+    echo "{ \"name\": \"api_call\", \"output\": \"delete\", \"process\": \"init\", \"user\": \"root\", \"status\": 1, \"handler\": \"${CLIENT_DEREGISTER_HANDLER}\"}" > \
     /dev/tcp/localhost/3030
 }
 

--- a/sensu_configs/init.d/sensu-service
+++ b/sensu_configs/init.d/sensu-service
@@ -197,6 +197,12 @@ wait_for_stop() {
     return $stopped
 }
 
+deregister_client() {
+    log_action_msg "Deregistering sensu-client"
+    echo "{ \"name\": \"api_call\", \"output\": \"delete\", \"process\": \"init\", \"user\": \"root\", \"status\": 2, \"handler\": \"${CLIENT_DEREGISTER_HANDLER}\"}" > \
+    /dev/tcp/localhost/3030
+}
+
 start() {
     log_daemon_msg "Starting $sensu_service"
 
@@ -235,6 +241,9 @@ start() {
 }
 
 stop() {
+    if [ "x$CLIENT_DEREGISTER_ON_STOP" = "xtrue" ]; then
+       deregister_client
+    fi
     log_daemon_msg "Stopping $sensu_service"
 
     # try pgrep


### PR DESCRIPTION
Provided that `CLIENT_DEREGISTER_ON_STOP` environment variable is set to `true` and `CLIENT_DEREGISTER_HANDLER` is set to `deregister`, the init script will send the following event to sensu-client on port 3030:

```
{ 
  "name": "api_call", 
  "output": "delete", 
  "process": "init", 
  "user": "root", 
  "status": 2, 
  "handler": "deregister" 
}
```

This event is intended to be processed by [the "deregister" handler](https://github.com/sensu-plugins/sensu-plugins-sensu/pull/1).