### PR TITLE
Update sensu-plugin version to 1.3.0

### DIFF
--- a/recipes/sensu_plugin.rake
+++ b/recipes/sensu_plugin.rake
@@ -1,7 +1,7 @@
 Bunchr::Software.new do |t|
   t.name = 'sensu_plugin'
 
-  t.version = '1.2.0'
+  t.version = '1.3.0'
 
   FileUtils.mkdir_p(t.work_dir)
 


### PR DESCRIPTION
We shipped 1.3.0 a week ago, no regressions reported as of yet. Can we please include this in the next release?