### PR TITLE
[sensu-plugin] update 1.3.0 dependency to 1.4.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ Bunchr::Packages.new do |t|
     t.include_software('runit')
     t.include_software('sensu')
     t.include_software('sensu_plugin_1.2.0')
-    t.include_software('sensu_plugin_1.3.0')
+    t.include_software('sensu_plugin_1.4.0')
     t.include_software('sensu_configs')
     t.include_software('sensu_bin_stubs')
 

--- a/recipes/sensu_plugin_1.4.0.rake
+++ b/recipes/sensu_plugin_1.4.0.rake
@@ -1,5 +1,5 @@
 Bunchr::Software.new do |t|
-  version = "1.3.0"
+  version = "1.4.0"
 
   t.name = "sensu_plugin_#{version}"
   t.version = version


### PR DESCRIPTION
Update dependency in support of efforts to [deprecate event filtering in sensu-plugin](https://sensuapp.org/blog/2016/07/07/sensu-plugin-filter-deprecation.html).