### PR TITLE
systemd config for ubuntu hosts in sensu-ctl

### DIFF
--- a/runit_scripts/sensu-ctl.rb
+++ b/runit_scripts/sensu-ctl.rb
@@ -135,7 +135,11 @@ def configure
   ohai.require_plugin("platform")
   case ohai.platform
   when "ubuntu"
-    setup_runsvdir_upstart
+    if ohai.platform_version >= '16.04'
+      setup_runsvdir_systemd
+    else ohai.platform_version < '16.04'
+      setup_runsvdir_upstart
+    end
   when "redhat", "centos", "rhel", "scientific"
     if ohai.platform_version =~ /^6/
       setup_runsvdir_upstart


### PR DESCRIPTION
When running `sensu-ctl configure` on a Ubuntu 16.04 host, I get `failed to find sensu-runsvdir job`. Since there is systemd logic in sensu-ctl, seems wise to use that behavior for systems that dont use upstart at all.

Potential future work: if a newer version of ohai is used, could use `ohai.init_package` to determine systemd status.